### PR TITLE
Add option to force transparent color

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	flag.BoolVar(&cl2ArchiveFlag, "cl2_archive", false, "store output in CL2 archive format")
 	flag.BoolVar(&useCIE2000, "cie2000", false, "use CIE Delta E 2000 instead of Euclidean colour conversion")
 	flag.IntVar(&useThreshold, "threshold", 0, "threshold amount for Euclidean colour conversion")
-	flag.IntVar(&nColorKey, "col_key", -1, "manually specify RGB value of transparent colour")
+	flag.IntVar(&nColorKey, "col_key", -1, "manually specify RGB value of transparent colour (e.g. 0xFF0000 for red)")
 	flag.StringVar(&output, "o", "output.cel", "CEL or CL2 image output path")
 	flag.StringVar(&palPath, "pal_path", "town.pal", "path to levels/towndata/town.pal")
 	flag.Usage = usage

--- a/main.go
+++ b/main.go
@@ -32,6 +32,8 @@ var (
 	useCIE2000 bool
 	// Threshold amount for Euclidean method.
 	useThreshold int
+	// Transparent colour value.
+	nColorKey int
 )
 
 func main() {
@@ -50,6 +52,7 @@ func main() {
 	flag.BoolVar(&cl2ArchiveFlag, "cl2_archive", false, "store output in CL2 archive format")
 	flag.BoolVar(&useCIE2000, "cie2000", false, "use CIE Delta E 2000 instead of Euclidean colour conversion")
 	flag.IntVar(&useThreshold, "threshold", 0, "threshold amount for Euclidean colour conversion")
+	flag.IntVar(&nColorKey, "col_key", -1, "manually specify RGB value of transparent colour")
 	flag.StringVar(&output, "o", "output.cel", "CEL or CL2 image output path")
 	flag.StringVar(&palPath, "pal_path", "town.pal", "path to levels/towndata/town.pal")
 	flag.Usage = usage
@@ -536,8 +539,21 @@ func dumpCL2Archive(cl2Archive *CL2Archive, output string) error {
 
 // isTransparent reports whether the given colour is transparent.
 func isTransparent(c color.Color) bool {
-	_, _, _, a := c.RGBA()
-	return a < 32768 // treat < 50% alpha as transparent.
+	r, g, b, a := c.RGBA()
+	if a < 32768 { // treat < 50% alpha as transparent.
+		return true
+	}
+
+	if nColorKey >= 0 { // user-specified alpha RGB
+		rr := (nColorKey >> 16) & 0xFF
+		gg := (nColorKey >> 8) & 0xFF
+		bb := nColorKey & 0xFF
+		if int(r) == rr && int(g) == gg && int(b) == bb {
+			return true
+		}
+	}
+
+	return false
 }
 
 // parsePal parses the given PAL file and returns the corresponding palette.

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ var (
 	// Threshold amount for Euclidean method.
 	useThreshold int
 	// Transparent colour value.
-	nColorKey int
+	colourKey int
 )
 
 func main() {
@@ -52,7 +52,7 @@ func main() {
 	flag.BoolVar(&cl2ArchiveFlag, "cl2_archive", false, "store output in CL2 archive format")
 	flag.BoolVar(&useCIE2000, "cie2000", false, "use CIE Delta E 2000 instead of Euclidean colour conversion")
 	flag.IntVar(&useThreshold, "threshold", 0, "threshold amount for Euclidean colour conversion")
-	flag.IntVar(&nColorKey, "col_key", -1, "manually specify RGB value of transparent colour (e.g. 0xFF0000 for red)")
+	flag.IntVar(&colourKey, "col_key", -1, "manually specify RGB value of transparent colour (e.g. 0xFF0000 for red)")
 	flag.StringVar(&output, "o", "output.cel", "CEL or CL2 image output path")
 	flag.StringVar(&palPath, "pal_path", "town.pal", "path to levels/towndata/town.pal")
 	flag.Usage = usage
@@ -544,10 +544,10 @@ func isTransparent(c color.Color) bool {
 		return true
 	}
 
-	if nColorKey >= 0 { // user-specified alpha RGB
-		rr := (nColorKey >> 16) & 0xFF
-		gg := (nColorKey >> 8) & 0xFF
-		bb := nColorKey & 0xFF
+	if colourKey >= 0 { // user-specified alpha RGB
+		rr := (colourKey >> 16) & 0xFF
+		gg := (colourKey >> 8) & 0xFF
+		bb := colourKey & 0xFF
 		if int(r) == rr && int(g) == gg && int(b) == bb {
 			return true
 		}


### PR DESCRIPTION
One of the issues I ran into recently was that I exported some graphics from a tool and had over 200 frames. The transparent color used in them was just solid black instead of an alpha channel. I also had another graphic which I set the transparent color using Gimp but it didn't convert right. I got it to finally work by forcing a certain RGB value to be treated as transparent.

Recommended to use hexadecimal: (format 0xRRGGBB)
```
pngs2cel -o test.cel -pal_path test.pal -col_key 0x113377 test.png
```