### PR TITLE
Fix color key conversion

### DIFF
--- a/main.go
+++ b/main.go
@@ -548,7 +548,7 @@ func isTransparent(c color.Color) bool {
 		rr := (colourKey >> 16) & 0xFF
 		gg := (colourKey >> 8) & 0xFF
 		bb := colourKey & 0xFF
-		if int(r) == rr && int(g) == gg && int(b) == bb {
+		if int(r >> 8) == rr && int(g >> 8) == gg && int(b >> 8) == bb {
 			return true
 		}
 	}


### PR DESCRIPTION
Fixes #9 

Color key now works properly.

Edit: for reference, you can now convert Diablo's UI PCX graphics to CEL by first saving them as PNG and using 0x00FF00 as the key.