### PR TITLE
A few small cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.cl2
 *.cel
 *.mpq
+*.exe
 diabdat


### PR DESCRIPTION
Removes the dummy alpha channel code I added because I didn't know at the time about using `_ = var` and it gave a compiler error without. Also added a commented out line that can help with conversion of green-dominate images.